### PR TITLE
Adds transaction history endpoint with pagination

### DIFF
--- a/src/main/java/com/code_factory/backend/transaction/application/port/in/ListTransactionsUseCase.java
+++ b/src/main/java/com/code_factory/backend/transaction/application/port/in/ListTransactionsUseCase.java
@@ -1,0 +1,9 @@
+package com.code_factory.backend.transaction.application.port.in;
+
+import com.code_factory.backend.transaction.domain.model.Transaction;
+import java.util.List;
+import java.util.UUID;
+
+public interface ListTransactionsUseCase {
+    List<Transaction> getHistoryByUserId(UUID userId, int limit, int offset);
+}

--- a/src/main/java/com/code_factory/backend/transaction/application/service/ListTransactionsService.java
+++ b/src/main/java/com/code_factory/backend/transaction/application/service/ListTransactionsService.java
@@ -1,0 +1,20 @@
+package com.code_factory.backend.transaction.application.service;
+
+import com.code_factory.backend.transaction.application.port.in.ListTransactionsUseCase;
+import com.code_factory.backend.transaction.application.port.out.TransactionRepositoryPort;
+import com.code_factory.backend.transaction.domain.model.Transaction;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ListTransactionsService implements ListTransactionsUseCase {
+    private final TransactionRepositoryPort transactionRepositoryPort;
+
+    @Override
+    public List<Transaction> getHistoryByUserId(UUID userId, int limit, int offset) {
+        return transactionRepositoryPort.findByUserId(userId, limit, offset);
+    }
+}

--- a/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/in/web/TransactionController.java
+++ b/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/in/web/TransactionController.java
@@ -1,14 +1,19 @@
 package com.code_factory.backend.transaction.infrastructure.adapter.in.web;
 
-import com.code_factory.backend.transaction.application.port.in.RegisterIncomeCommand;
+import com.code_factory.backend.classification.application.port.out.CategoryRepositoryPort;
+import com.code_factory.backend.transaction.application.port.in.ListTransactionsUseCase;
 import com.code_factory.backend.transaction.application.port.in.RegisterTransactionUseCase;
+import com.code_factory.backend.transaction.application.port.in.RegisterIncomeCommand;
 import com.code_factory.backend.transaction.domain.model.Transaction;
 import com.code_factory.backend.transaction.infrastructure.adapter.in.web.dto.RegisterIncomeRequest;
+import com.code_factory.backend.transaction.infrastructure.adapter.in.web.dto.TransactionResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/transactions")
@@ -16,6 +21,8 @@ import org.springframework.web.bind.annotation.*;
 public class TransactionController {
 
     private final RegisterTransactionUseCase registerTransactionUseCase;
+    private final ListTransactionsUseCase listTransactionsUseCase;
+    private final CategoryRepositoryPort categoryRepositoryPort; // Integración con módulo Classification
 
     @PostMapping("/income")
     public ResponseEntity<Transaction> registerIncome(@Valid @RequestBody RegisterIncomeRequest request) {
@@ -28,5 +35,32 @@ public class TransactionController {
         );
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(registerTransactionUseCase.registerIncome(command));
+    }
+
+    @GetMapping("/history/{userId}")
+    public ResponseEntity<List<TransactionResponse>> getHistory(
+            @PathVariable UUID userId,
+            @RequestParam(defaultValue = "10") int limit,
+            @RequestParam(defaultValue = "0") int offset) {
+
+        List<TransactionResponse> history = listTransactionsUseCase.getHistoryByUserId(userId, limit, offset)
+                .stream()
+                .map(t -> {
+                    // Enriquecimiento de datos consultando el puerto de categorías
+                    var category = categoryRepositoryPort.findById(t.getCategoryId()).orElse(null);
+                    
+                    return TransactionResponse.builder()
+                            .id(t.getId())
+                            .amount(t.getAmount())
+                            .description(t.getDescription())
+                            .transactionDate(t.getTransactionDate())
+                            .categoryId(t.getCategoryId())
+                            .categoryName(category != null ? category.getName() : "Desconocida")
+                            .categoryType(category != null ? category.getType() : null)
+                            .build();
+                })
+                .toList();
+
+        return ResponseEntity.ok(history);
     }
 }

--- a/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/in/web/dto/TransactionResponse.java
+++ b/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/in/web/dto/TransactionResponse.java
@@ -1,0 +1,22 @@
+package com.code_factory.backend.transaction.infrastructure.adapter.in.web.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import com.code_factory.backend.classification.domain.model.CategoryType;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class TransactionResponse {
+    private UUID id;
+    private BigDecimal amount;
+    private String description;
+    private LocalDate transactionDate;
+    private UUID categoryId;
+    private String categoryName;
+    private CategoryType categoryType;
+}


### PR DESCRIPTION
This pull request adds a new feature for listing a user's transaction history, including category enrichment, and introduces the necessary service, use case, and DTO to support this endpoint. The main changes are grouped below:

**Transaction History Feature**

* Added a new endpoint `GET /api/v1/transactions/history/{userId}` to `TransactionController` that returns a paginated list of transactions for a user, with optional `limit` and `offset` parameters. Each transaction in the response includes enriched category information (name and type) by querying the category module. [[1]](diffhunk://#diff-12f7aa8fb69febe3d69aab6e3b9e6ce712307df2ff945f9a5843fbd22534f18eL3-R25) [[2]](diffhunk://#diff-12f7aa8fb69febe3d69aab6e3b9e6ce712307df2ff945f9a5843fbd22534f18eR39-R65)

**Application Layer**

* Introduced the `ListTransactionsUseCase` interface, defining a method to retrieve a user's transaction history with pagination support.
* Implemented the `ListTransactionsService` class, which uses the `TransactionRepositoryPort` to fetch transactions according to the use case.

**DTOs**

* Added the `TransactionResponse` DTO to structure the API response, including fields for transaction details and enriched category information.Implements transaction history retrieval functionality that allows users to query their past transactions with pagination support.

Creates a new use case and service layer for listing transactions by user ID with configurable limit and offset parameters.

Enriches transaction responses with category information by integrating with the Classification module, providing category name and type alongside transaction details.

Enables clients to access transaction history through a REST endpoint that returns formatted responses including all relevant transaction and category data.