### PR TITLE
Adds category type filtering to transaction history

### DIFF
--- a/src/main/java/com/code_factory/backend/transaction/application/port/in/ListTransactionsUseCase.java
+++ b/src/main/java/com/code_factory/backend/transaction/application/port/in/ListTransactionsUseCase.java
@@ -1,9 +1,10 @@
 package com.code_factory.backend.transaction.application.port.in;
 
+import com.code_factory.backend.classification.domain.model.CategoryType;
 import com.code_factory.backend.transaction.domain.model.Transaction;
 import java.util.List;
 import java.util.UUID;
 
 public interface ListTransactionsUseCase {
-    List<Transaction> getHistoryByUserId(UUID userId, int limit, int offset);
+    List<Transaction> getHistoryByUserId(UUID userId, CategoryType type, int limit, int offset);
 }

--- a/src/main/java/com/code_factory/backend/transaction/application/port/out/TransactionRepositoryPort.java
+++ b/src/main/java/com/code_factory/backend/transaction/application/port/out/TransactionRepositoryPort.java
@@ -1,5 +1,6 @@
 package com.code_factory.backend.transaction.application.port.out;
 
+import com.code_factory.backend.classification.domain.model.CategoryType;
 import com.code_factory.backend.transaction.domain.model.Transaction;
 import java.util.List;
 import java.util.Optional;
@@ -12,7 +13,7 @@ public interface TransactionRepositoryPort {
 
     // Para futuras consultas (Paginación agnóstica)
     // Usamos tipos simples de Java
-    List<Transaction> findByUserId(UUID userId, int limit, int offset);
+    List<Transaction> findByUserIdAndType(UUID userId, CategoryType type, int limit, int offset);
     
     Optional<Transaction> findById(UUID id);
 }

--- a/src/main/java/com/code_factory/backend/transaction/application/service/ListTransactionsService.java
+++ b/src/main/java/com/code_factory/backend/transaction/application/service/ListTransactionsService.java
@@ -1,5 +1,6 @@
 package com.code_factory.backend.transaction.application.service;
 
+import com.code_factory.backend.classification.domain.model.CategoryType;
 import com.code_factory.backend.transaction.application.port.in.ListTransactionsUseCase;
 import com.code_factory.backend.transaction.application.port.out.TransactionRepositoryPort;
 import com.code_factory.backend.transaction.domain.model.Transaction;
@@ -14,7 +15,7 @@ public class ListTransactionsService implements ListTransactionsUseCase {
     private final TransactionRepositoryPort transactionRepositoryPort;
 
     @Override
-    public List<Transaction> getHistoryByUserId(UUID userId, int limit, int offset) {
-        return transactionRepositoryPort.findByUserId(userId, limit, offset);
+    public List<Transaction> getHistoryByUserId(UUID userId, CategoryType type, int limit, int offset) {
+        return transactionRepositoryPort.findByUserIdAndType(userId, type, limit, offset);
     }
 }

--- a/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/in/web/TransactionController.java
+++ b/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/in/web/TransactionController.java
@@ -1,6 +1,7 @@
 package com.code_factory.backend.transaction.infrastructure.adapter.in.web;
 
 import com.code_factory.backend.classification.application.port.out.CategoryRepositoryPort;
+import com.code_factory.backend.classification.domain.model.CategoryType;
 import com.code_factory.backend.transaction.application.port.in.ListTransactionsUseCase;
 import com.code_factory.backend.transaction.application.port.in.RegisterIncomeCommand;
 import com.code_factory.backend.transaction.application.port.in.RegisterIncomeUseCase;
@@ -57,17 +58,17 @@ public class TransactionController {
                 .body(registerExpenseUseCase.registerExpense(command));
     }
 
-    @GetMapping("/history/{userId}")
+@GetMapping("/history/{userId}")
     public ResponseEntity<List<TransactionResponse>> getHistory(
             @PathVariable UUID userId,
+            @RequestParam(required = false) CategoryType type, // El filtro mágico
             @RequestParam(defaultValue = "10") int limit,
             @RequestParam(defaultValue = "0") int offset) {
 
-        List<TransactionResponse> history = listTransactionsUseCase.getHistoryByUserId(userId, limit, offset)
+        List<TransactionResponse> history = listTransactionsUseCase.getHistoryByUserId(userId, type, limit, offset)
                 .stream()
                 .map(t -> {
                     var category = categoryRepositoryPort.findById(t.getCategoryId()).orElse(null);
-                    
                     return TransactionResponse.builder()
                             .id(t.getId())
                             .amount(t.getAmount())

--- a/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/out/persistence/adapter/TransactionPersistenceAdapter.java
+++ b/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/out/persistence/adapter/TransactionPersistenceAdapter.java
@@ -1,16 +1,13 @@
 package com.code_factory.backend.transaction.infrastructure.adapter.out.persistence.adapter;
 
+import com.code_factory.backend.classification.domain.model.CategoryType;
 import com.code_factory.backend.transaction.application.port.out.TransactionRepositoryPort;
 import com.code_factory.backend.transaction.domain.model.Transaction;
-import com.code_factory.backend.transaction.infrastructure.adapter.out.persistence.entity.TransactionEntity;
 import com.code_factory.backend.transaction.infrastructure.adapter.out.persistence.mapper.TransactionMapper;
 import com.code_factory.backend.transaction.infrastructure.adapter.out.persistence.repository.JpaTransactionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
-
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -18,31 +15,23 @@ import java.util.UUID;
 @Component
 @RequiredArgsConstructor
 public class TransactionPersistenceAdapter implements TransactionRepositoryPort {
-
     private final JpaTransactionRepository repository;
     private final TransactionMapper mapper;
 
     @Override
     public Transaction save(Transaction transaction) {
-        TransactionEntity entity = mapper.toEntity(transaction);
-        // Seteamos la auditoría que el dominio no conoce
-        entity.setCreatedAt(LocalDateTime.now());
-        TransactionEntity savedEntity = repository.save(entity);
-        return mapper.toDomain(savedEntity);
+        return mapper.toDomain(repository.save(mapper.toEntity(transaction)));
     }
 
     @Override
     public Optional<Transaction> findById(UUID id) {
-        return repository.findById(id)
-                .map(mapper::toDomain);
+        return repository.findById(id).map(mapper::toDomain);
     }
 
     @Override
-    public List<Transaction> findByUserId(UUID userId, int limit, int offset) {
-        // Traducimos el estándar del puerto (limit/offset) al estándar de Spring (Pageable)
-        Pageable pageable = PageRequest.of(offset / limit, limit);
-        
-        return repository.findByUserIdOrderByTransactionDateDesc(userId, pageable)
+    public List<Transaction> findByUserIdAndType(UUID userId, CategoryType type, int limit, int offset) {
+        var pageable = PageRequest.of(offset / limit, limit);
+        return repository.findByUserIdAndType(userId, type, pageable)
                 .stream()
                 .map(mapper::toDomain)
                 .toList();

--- a/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/out/persistence/repository/JpaTransactionRepository.java
+++ b/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/out/persistence/repository/JpaTransactionRepository.java
@@ -1,13 +1,24 @@
 package com.code_factory.backend.transaction.infrastructure.adapter.out.persistence.repository;
 
+import com.code_factory.backend.classification.domain.model.CategoryType;
 import com.code_factory.backend.transaction.infrastructure.adapter.out.persistence.entity.TransactionEntity;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.UUID;
 
 public interface JpaTransactionRepository extends JpaRepository<TransactionEntity, UUID> {
-    // En JpaTransactionRepository.java
-    Page<TransactionEntity> findByUserIdOrderByTransactionDateDesc(UUID userId, Pageable pageable);
+    
+    @Query("SELECT t FROM TransactionEntity t " +
+           "JOIN CategoryEntity c ON t.categoryId = c.id " +
+           "WHERE t.userId = :userId " +
+           "AND (:type IS NULL OR c.type = :type) " +
+           "ORDER BY t.transactionDate DESC")
+    Page<TransactionEntity> findByUserIdAndType(
+            @Param("userId") UUID userId, 
+            @Param("type") CategoryType type, 
+            Pageable pageable
+    );
 }


### PR DESCRIPTION
This pull request updates the transaction history retrieval functionality to support filtering by `CategoryType`. The changes ensure that users can now fetch transactions for a specific category type (such as income or expense) in addition to the existing pagination options.

**Enhancements to transaction history filtering:**

* The `ListTransactionsUseCase` interface and its implementation in `ListTransactionsService` have been updated to accept a `CategoryType` parameter, enabling filtering of transactions by category type. [[1]](diffhunk://#diff-31a69fa21c63e9f161f048f7e06e3dff799cd6f89bfc136b43ab53bdc77868aeR3-R9) [[2]](diffhunk://#diff-effe7b389c991807e8650d17be293eba0b3c8f4816c2bc2fa54ae3714ef4b002L17-R19)
* The `TransactionController`'s `getHistory` endpoint now accepts an optional `type` request parameter, which is passed through the service layer to filter results accordingly.
* The service implementation now calls a repository method (`findByUserIdAndType`) that supports filtering by both user ID and category type.

These changes allow clients to retrieve transaction histories filtered by category type, improving the flexibility and usefulness of the transaction API.Enables filtering transaction history by category type (income/expense) to allow users to view specific transaction types separately.

Extends the transaction retrieval flow by adding an optional category type parameter throughout the stack - from the controller endpoint through the service layer to the repository port.

The filter is optional at the API level, maintaining backward compatibility while providing more granular control over transaction queries.