### PR TITLE
Adds CORS configuration for frontend integration

### DIFF
--- a/src/main/java/com/code_factory/backend/shared/config/CorsConfig.java
+++ b/src/main/java/com/code_factory/backend/shared/config/CorsConfig.java
@@ -1,0 +1,23 @@
+package com.code_factory.backend.shared.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/api/v1/**")
+                        .allowedOrigins("http://localhost:3000", "http://localhost:5173") //configuración para permitir solicitudes desde el frontend
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}


### PR DESCRIPTION
This pull request introduces a new CORS configuration to the backend. The main change is the addition of a configuration class that allows cross-origin requests from specified frontend origins, enabling smoother integration between the frontend and backend during development.

**CORS configuration:**

* Added a new `CorsConfig` class that defines a `WebMvcConfigurer` bean to allow CORS requests from `http://localhost:3000` and `http://localhost:5173` for all `/api/v1/**` endpoints, supporting common HTTP methods and credentials.Configures CORS to allow cross-origin requests from local development servers on ports 3000 and 5173.

Enables GET, POST, PUT, DELETE, and OPTIONS methods for API endpoints under /api/v1/**, allowing credentials and all headers to support frontend-backend communication during development.