### PR TITLE
feat(transaction): HU 3.2.1 Eliminar una transacción

### DIFF
--- a/src/main/java/com/code_factory/backend/transaction/application/port/in/DeleteTransactionCommand.java
+++ b/src/main/java/com/code_factory/backend/transaction/application/port/in/DeleteTransactionCommand.java
@@ -1,0 +1,5 @@
+package com.code_factory.backend.transaction.application.port.in;
+
+import java.util.UUID;
+
+public record DeleteTransactionCommand(UUID transactionId, UUID userId) {}

--- a/src/main/java/com/code_factory/backend/transaction/application/port/in/DeleteTransactionUseCase.java
+++ b/src/main/java/com/code_factory/backend/transaction/application/port/in/DeleteTransactionUseCase.java
@@ -1,0 +1,5 @@
+package com.code_factory.backend.transaction.application.port.in;
+
+public interface DeleteTransactionUseCase {
+    void deleteTransaction(DeleteTransactionCommand command);
+}

--- a/src/main/java/com/code_factory/backend/transaction/application/port/out/TransactionRepositoryPort.java
+++ b/src/main/java/com/code_factory/backend/transaction/application/port/out/TransactionRepositoryPort.java
@@ -16,4 +16,6 @@ public interface TransactionRepositoryPort {
     List<Transaction> findByUserIdAndType(UUID userId, CategoryType type, int limit, int offset);
     
     Optional<Transaction> findById(UUID id);
+
+    void delete(UUID id);
 }

--- a/src/main/java/com/code_factory/backend/transaction/application/service/DeleteTransactionService.java
+++ b/src/main/java/com/code_factory/backend/transaction/application/service/DeleteTransactionService.java
@@ -1,0 +1,32 @@
+package com.code_factory.backend.transaction.application.service;
+
+import com.code_factory.backend.transaction.application.port.in.DeleteTransactionCommand;
+import com.code_factory.backend.transaction.application.port.in.DeleteTransactionUseCase;
+import com.code_factory.backend.transaction.application.port.out.TransactionRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteTransactionService implements DeleteTransactionUseCase {
+
+    private final TransactionRepositoryPort transactionRepositoryPort;
+
+    @Override
+    public void deleteTransaction(DeleteTransactionCommand command) {
+        var transaction = transactionRepositoryPort.findById(command.transactionId())
+                .orElseThrow(() -> new RuntimeException("Transacción no encontrada"));
+
+        if (!transaction.getUserId().equals(command.userId())) {
+            throw new RuntimeException("No tienes permiso para eliminar esta transacción");
+        }
+
+        if (transaction.getCreatedAt() == null || transaction.getCreatedAt().isBefore(LocalDateTime.now().minusHours(48))) {
+            throw new RuntimeException("La transacción solo puede eliminarse dentro de las 48 horas siguientes a su creación");
+        }
+
+        transactionRepositoryPort.delete(command.transactionId());
+    }
+}

--- a/src/main/java/com/code_factory/backend/transaction/domain/model/Transaction.java
+++ b/src/main/java/com/code_factory/backend/transaction/domain/model/Transaction.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
@@ -15,4 +16,5 @@ public class Transaction {
     private final BigDecimal amount;
     private final String description;
     private final LocalDate transactionDate;
+    private final LocalDateTime createdAt;
 }

--- a/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/in/web/TransactionController.java
+++ b/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/in/web/TransactionController.java
@@ -2,6 +2,8 @@ package com.code_factory.backend.transaction.infrastructure.adapter.in.web;
 
 import com.code_factory.backend.classification.application.port.out.CategoryRepositoryPort;
 import com.code_factory.backend.classification.domain.model.CategoryType;
+import com.code_factory.backend.transaction.application.port.in.DeleteTransactionCommand;
+import com.code_factory.backend.transaction.application.port.in.DeleteTransactionUseCase;
 import com.code_factory.backend.transaction.application.port.in.ListTransactionsUseCase;
 import com.code_factory.backend.transaction.application.port.in.RegisterIncomeCommand;
 import com.code_factory.backend.transaction.application.port.in.RegisterIncomeUseCase;
@@ -28,6 +30,7 @@ public class TransactionController {
     private final RegisterIncomeUseCase registerIncomeUseCase;
     private final RegisterExpenseUseCase registerExpenseUseCase;
     private final ListTransactionsUseCase listTransactionsUseCase;
+    private final DeleteTransactionUseCase deleteTransactionUseCase;
     private final CategoryRepositoryPort categoryRepositoryPort;
 
     @PostMapping("/income")
@@ -82,5 +85,13 @@ public class TransactionController {
                 .toList();
 
         return ResponseEntity.ok(history);
+    }
+
+    @DeleteMapping("/{transactionId}")
+    public ResponseEntity<Void> deleteTransaction(
+            @PathVariable UUID transactionId,
+            @RequestParam UUID userId) {
+        deleteTransactionUseCase.deleteTransaction(new DeleteTransactionCommand(transactionId, userId));
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/out/persistence/adapter/TransactionPersistenceAdapter.java
+++ b/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/out/persistence/adapter/TransactionPersistenceAdapter.java
@@ -36,4 +36,9 @@ public class TransactionPersistenceAdapter implements TransactionRepositoryPort 
                 .map(mapper::toDomain)
                 .toList();
     }
+
+    @Override
+    public void delete(UUID id) {
+        repository.deleteById(id);
+    }
 }

--- a/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/out/persistence/entity/TransactionEntity.java
+++ b/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/out/persistence/entity/TransactionEntity.java
@@ -21,4 +21,11 @@ public class TransactionEntity {
 
     @Column(updatable = false)
     private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
 }

--- a/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/out/persistence/mapper/TransactionMapper.java
+++ b/src/main/java/com/code_factory/backend/transaction/infrastructure/adapter/out/persistence/mapper/TransactionMapper.java
@@ -25,6 +25,7 @@ public class TransactionMapper {
                 .amount(entity.getAmount())
                 .description(entity.getDescription())
                 .transactionDate(entity.getTransactionDate())
+                .createdAt(entity.getCreatedAt())
                 .build();
     }
 }


### PR DESCRIPTION
Closes #9

## Summary

- Nuevo endpoint `DELETE /api/v1/transactions/{transactionId}?userId={userId}` → `204 No Content`
- Eliminar solo permitido dentro de **48 horas** desde creación (regla de negocio)
- Fix: `TransactionEntity` no tenía `@PrePersist` — `createdAt` se guardaba `NULL` en DB para todas las transacciones existentes

## Evidencia

[Video de evidencia](https://anderson.neetorecord.com/watch/46778717cb80c751e952)

## Cambios

| Capa | Acción | Archivo |
|------|--------|---------|
| Domain | `createdAt: LocalDateTime` expuesto | `Transaction.java` |
| Application | Input port + command | `DeleteTransactionUseCase`, `DeleteTransactionCommand` |
| Application | Servicio con validaciones | `DeleteTransactionService` |
| Application | `delete(UUID)` en output port | `TransactionRepositoryPort` |
| Infrastructure | `@PrePersist` para auto-setear `createdAt` | `TransactionEntity` |
| Infrastructure | Mapeo de `createdAt` | `TransactionMapper` |
| Infrastructure | Implementación `delete` | `TransactionPersistenceAdapter` |
| Infrastructure | Endpoint DELETE registrado | `TransactionController` |

## Validaciones del servicio

1. Transacción no encontrada → `400 "Transacción no encontrada"`
2. `userId` no coincide → `400 "No tienes permiso para eliminar esta transacción"`
3. Fuera de ventana 48h (o `createdAt` null) → `400 "La transacción solo puede eliminarse dentro de las 48 horas siguientes a su creación"`

