### PR TITLE
feat(budgeting): create and list monthly budgets — HU 5.1.1 Crear un presupuesto mensual

### DIFF
--- a/src/main/java/com/code_factory/backend/budgeting/application/port/in/CreateBudgetCommand.java
+++ b/src/main/java/com/code_factory/backend/budgeting/application/port/in/CreateBudgetCommand.java
@@ -1,0 +1,12 @@
+package com.code_factory.backend.budgeting.application.port.in;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record CreateBudgetCommand(
+        UUID userId,
+        LocalDate month,
+        BigDecimal totalIncome,
+        BigDecimal expenseLimit
+) {}

--- a/src/main/java/com/code_factory/backend/budgeting/application/port/in/CreateBudgetUseCase.java
+++ b/src/main/java/com/code_factory/backend/budgeting/application/port/in/CreateBudgetUseCase.java
@@ -1,0 +1,7 @@
+package com.code_factory.backend.budgeting.application.port.in;
+
+import com.code_factory.backend.budgeting.domain.model.Budget;
+
+public interface CreateBudgetUseCase {
+    Budget createBudget(CreateBudgetCommand command);
+}

--- a/src/main/java/com/code_factory/backend/budgeting/application/port/in/ListBudgetsUseCase.java
+++ b/src/main/java/com/code_factory/backend/budgeting/application/port/in/ListBudgetsUseCase.java
@@ -1,0 +1,9 @@
+package com.code_factory.backend.budgeting.application.port.in;
+
+import com.code_factory.backend.budgeting.domain.model.Budget;
+import java.util.List;
+import java.util.UUID;
+
+public interface ListBudgetsUseCase {
+    List<Budget> getBudgetsByUserId(UUID userId);
+}

--- a/src/main/java/com/code_factory/backend/budgeting/application/port/out/BudgetRepositoryPort.java
+++ b/src/main/java/com/code_factory/backend/budgeting/application/port/out/BudgetRepositoryPort.java
@@ -1,0 +1,13 @@
+package com.code_factory.backend.budgeting.application.port.out;
+
+import com.code_factory.backend.budgeting.domain.model.Budget;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface BudgetRepositoryPort {
+    Budget save(Budget budget);
+    List<Budget> findByUserId(UUID userId);
+    Optional<Budget> findByUserIdAndMonth(UUID userId, LocalDate month);
+}

--- a/src/main/java/com/code_factory/backend/budgeting/application/service/CreateBudgetService.java
+++ b/src/main/java/com/code_factory/backend/budgeting/application/service/CreateBudgetService.java
@@ -1,0 +1,41 @@
+package com.code_factory.backend.budgeting.application.service;
+
+import com.code_factory.backend.budgeting.application.port.in.CreateBudgetCommand;
+import com.code_factory.backend.budgeting.application.port.in.CreateBudgetUseCase;
+import com.code_factory.backend.budgeting.application.port.out.BudgetRepositoryPort;
+import com.code_factory.backend.budgeting.domain.model.Budget;
+import com.code_factory.backend.identity.application.port.out.UserRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CreateBudgetService implements CreateBudgetUseCase {
+
+    private final BudgetRepositoryPort budgetRepositoryPort;
+    private final UserRepositoryPort userRepositoryPort;
+
+    @Override
+    public Budget createBudget(CreateBudgetCommand command) {
+        userRepositoryPort.findById(command.userId())
+                .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
+
+        LocalDate firstOfMonth = command.month().withDayOfMonth(1);
+
+        budgetRepositoryPort.findByUserIdAndMonth(command.userId(), firstOfMonth)
+                .ifPresent(b -> { throw new RuntimeException("Ya existe un presupuesto para este mes"); });
+
+        Budget budget = Budget.builder()
+                .id(UUID.randomUUID())
+                .userId(command.userId())
+                .month(firstOfMonth)
+                .totalIncome(command.totalIncome())
+                .expenseLimit(command.expenseLimit())
+                .build();
+
+        return budgetRepositoryPort.save(budget);
+    }
+}

--- a/src/main/java/com/code_factory/backend/budgeting/application/service/ListBudgetsService.java
+++ b/src/main/java/com/code_factory/backend/budgeting/application/service/ListBudgetsService.java
@@ -1,0 +1,22 @@
+package com.code_factory.backend.budgeting.application.service;
+
+import com.code_factory.backend.budgeting.application.port.in.ListBudgetsUseCase;
+import com.code_factory.backend.budgeting.application.port.out.BudgetRepositoryPort;
+import com.code_factory.backend.budgeting.domain.model.Budget;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ListBudgetsService implements ListBudgetsUseCase {
+
+    private final BudgetRepositoryPort budgetRepositoryPort;
+
+    @Override
+    public List<Budget> getBudgetsByUserId(UUID userId) {
+        return budgetRepositoryPort.findByUserId(userId);
+    }
+}

--- a/src/main/java/com/code_factory/backend/budgeting/domain/model/Budget.java
+++ b/src/main/java/com/code_factory/backend/budgeting/domain/model/Budget.java
@@ -1,0 +1,19 @@
+package com.code_factory.backend.budgeting.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class Budget {
+    private final UUID id;
+    private final UUID userId;
+    private final LocalDate month;
+    private final BigDecimal totalIncome;
+    private final BigDecimal expenseLimit;
+    private final LocalDateTime createdAt;
+}

--- a/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/in/web/BudgetController.java
+++ b/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/in/web/BudgetController.java
@@ -1,0 +1,60 @@
+package com.code_factory.backend.budgeting.infrastructure.adapter.in.web;
+
+import com.code_factory.backend.budgeting.application.port.in.CreateBudgetCommand;
+import com.code_factory.backend.budgeting.application.port.in.CreateBudgetUseCase;
+import com.code_factory.backend.budgeting.application.port.in.ListBudgetsUseCase;
+import com.code_factory.backend.budgeting.infrastructure.adapter.in.web.dto.BudgetResponse;
+import com.code_factory.backend.budgeting.infrastructure.adapter.in.web.dto.CreateBudgetRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/budgets")
+@RequiredArgsConstructor
+public class BudgetController {
+
+    private final CreateBudgetUseCase createBudgetUseCase;
+    private final ListBudgetsUseCase listBudgetsUseCase;
+
+    @PostMapping
+    public ResponseEntity<BudgetResponse> createBudget(@Valid @RequestBody CreateBudgetRequest request) {
+        var command = new CreateBudgetCommand(
+                request.getUserId(),
+                request.getMonth(),
+                request.getTotalIncome(),
+                request.getExpenseLimit()
+        );
+        var budget = createBudgetUseCase.createBudget(command);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(BudgetResponse.builder()
+                        .id(budget.getId())
+                        .userId(budget.getUserId())
+                        .month(budget.getMonth())
+                        .totalIncome(budget.getTotalIncome())
+                        .expenseLimit(budget.getExpenseLimit())
+                        .createdAt(budget.getCreatedAt())
+                        .build());
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<List<BudgetResponse>> getBudgetsByUser(@PathVariable UUID userId) {
+        List<BudgetResponse> budgets = listBudgetsUseCase.getBudgetsByUserId(userId)
+                .stream()
+                .map(b -> BudgetResponse.builder()
+                        .id(b.getId())
+                        .userId(b.getUserId())
+                        .month(b.getMonth())
+                        .totalIncome(b.getTotalIncome())
+                        .expenseLimit(b.getExpenseLimit())
+                        .createdAt(b.getCreatedAt())
+                        .build())
+                .toList();
+        return ResponseEntity.ok(budgets);
+    }
+}

--- a/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/in/web/dto/BudgetResponse.java
+++ b/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/in/web/dto/BudgetResponse.java
@@ -1,0 +1,19 @@
+package com.code_factory.backend.budgeting.infrastructure.adapter.in.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class BudgetResponse {
+    private UUID id;
+    private UUID userId;
+    private LocalDate month;
+    private BigDecimal totalIncome;
+    private BigDecimal expenseLimit;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/in/web/dto/CreateBudgetRequest.java
+++ b/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/in/web/dto/CreateBudgetRequest.java
@@ -1,0 +1,26 @@
+package com.code_factory.backend.budgeting.infrastructure.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Data;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Data
+public class CreateBudgetRequest {
+
+    @NotNull(message = "El ID de usuario es obligatorio")
+    private UUID userId;
+
+    @NotNull(message = "El mes es obligatorio")
+    private LocalDate month;
+
+    @NotNull(message = "Los ingresos son obligatorios")
+    @Positive(message = "Los ingresos deben ser mayores a 0")
+    private BigDecimal totalIncome;
+
+    @NotNull(message = "El límite de gastos es obligatorio")
+    @Positive(message = "El límite de gastos debe ser mayor a 0")
+    private BigDecimal expenseLimit;
+}

--- a/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/out/persistence/adapter/BudgetPersistenceAdapter.java
+++ b/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/out/persistence/adapter/BudgetPersistenceAdapter.java
@@ -1,0 +1,38 @@
+package com.code_factory.backend.budgeting.infrastructure.adapter.out.persistence.adapter;
+
+import com.code_factory.backend.budgeting.application.port.out.BudgetRepositoryPort;
+import com.code_factory.backend.budgeting.domain.model.Budget;
+import com.code_factory.backend.budgeting.infrastructure.adapter.out.persistence.mapper.BudgetMapper;
+import com.code_factory.backend.budgeting.infrastructure.adapter.out.persistence.repository.JpaBudgetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class BudgetPersistenceAdapter implements BudgetRepositoryPort {
+
+    private final JpaBudgetRepository repository;
+    private final BudgetMapper mapper;
+
+    @Override
+    public Budget save(Budget budget) {
+        return mapper.toDomain(repository.save(mapper.toEntity(budget)));
+    }
+
+    @Override
+    public List<Budget> findByUserId(UUID userId) {
+        return repository.findByUserId(userId).stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public Optional<Budget> findByUserIdAndMonth(UUID userId, LocalDate month) {
+        return repository.findByUserIdAndMonth(userId, month).map(mapper::toDomain);
+    }
+}

--- a/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/out/persistence/entity/BudgetEntity.java
+++ b/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/out/persistence/entity/BudgetEntity.java
@@ -1,0 +1,42 @@
+package com.code_factory.backend.budgeting.infrastructure.adapter.out.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "budgets",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "month"})
+)
+@Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+public class BudgetEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false)
+    private LocalDate month;
+
+    @Column(name = "total_income", nullable = false, precision = 15, scale = 2)
+    private BigDecimal totalIncome;
+
+    @Column(name = "expense_limit", nullable = false, precision = 15, scale = 2)
+    private BigDecimal expenseLimit;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/out/persistence/mapper/BudgetMapper.java
+++ b/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/out/persistence/mapper/BudgetMapper.java
@@ -1,0 +1,30 @@
+package com.code_factory.backend.budgeting.infrastructure.adapter.out.persistence.mapper;
+
+import com.code_factory.backend.budgeting.domain.model.Budget;
+import com.code_factory.backend.budgeting.infrastructure.adapter.out.persistence.entity.BudgetEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BudgetMapper {
+
+    public BudgetEntity toEntity(Budget domain) {
+        return BudgetEntity.builder()
+                .id(domain.getId())
+                .userId(domain.getUserId())
+                .month(domain.getMonth())
+                .totalIncome(domain.getTotalIncome())
+                .expenseLimit(domain.getExpenseLimit())
+                .build();
+    }
+
+    public Budget toDomain(BudgetEntity entity) {
+        return Budget.builder()
+                .id(entity.getId())
+                .userId(entity.getUserId())
+                .month(entity.getMonth())
+                .totalIncome(entity.getTotalIncome())
+                .expenseLimit(entity.getExpenseLimit())
+                .createdAt(entity.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/out/persistence/repository/JpaBudgetRepository.java
+++ b/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/out/persistence/repository/JpaBudgetRepository.java
@@ -1,0 +1,13 @@
+package com.code_factory.backend.budgeting.infrastructure.adapter.out.persistence.repository;
+
+import com.code_factory.backend.budgeting.infrastructure.adapter.out.persistence.entity.BudgetEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface JpaBudgetRepository extends JpaRepository<BudgetEntity, UUID> {
+    List<BudgetEntity> findByUserId(UUID userId);
+    Optional<BudgetEntity> findByUserIdAndMonth(UUID userId, LocalDate month);
+}


### PR DESCRIPTION
Cierra #11

## Resumen

- Nueva tabla `budgets` con constraint único `(user_id, month)`
- `POST /api/v1/budgets` — crear presupuesto mensual con ingresos y límite de gastos
- `GET /api/v1/budgets/{userId}` — listar presupuestos de un usuario
- Valida existencia del usuario y presupuesto duplicado para el mismo mes

## Evidencia

[Video de evidencia.](https://ander20.neetorecord.com/watch/ea0417c7ecd7038444a6)

## Continuación 

1. [Issue HU 5.1.2](https://github.com/Dalev10/code-factory-2026-backend/issues/13)
2. [Issue HU 5.2.1](https://github.com/Dalev10/code-factory-2026-backend/issues/14)