### PR TITLE
HU 5.3.1: implementar edición de presupuesto mensual

### DIFF
--- a/src/main/java/com/code_factory/backend/budgeting/application/port/in/UpdateBudgetUseCase.java
+++ b/src/main/java/com/code_factory/backend/budgeting/application/port/in/UpdateBudgetUseCase.java
@@ -1,0 +1,8 @@
+package com.code_factory.backend.budgeting.application.port.in;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public interface UpdateBudgetUseCase {
+    void updateExpenseLimit(UUID userId, BigDecimal newLimit);
+}

--- a/src/main/java/com/code_factory/backend/budgeting/application/port/out/BudgetRepositoryPort.java
+++ b/src/main/java/com/code_factory/backend/budgeting/application/port/out/BudgetRepositoryPort.java
@@ -1,13 +1,26 @@
 package com.code_factory.backend.budgeting.application.port.out;
 
 import com.code_factory.backend.budgeting.domain.model.Budget;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface BudgetRepositoryPort {
+
+    /**
+     * Guarda o actualiza un presupuesto
+     */
     Budget save(Budget budget);
+
+    /**
+     * Obtiene todos los presupuestos de un usuario
+     */
     List<Budget> findByUserId(UUID userId);
+
+    /**
+     * Obtiene el presupuesto de un usuario en un mes específico
+     */
     Optional<Budget> findByUserIdAndMonth(UUID userId, LocalDate month);
 }

--- a/src/main/java/com/code_factory/backend/budgeting/application/service/UpdateBudgetService.java
+++ b/src/main/java/com/code_factory/backend/budgeting/application/service/UpdateBudgetService.java
@@ -1,0 +1,32 @@
+package com.code_factory.backend.budgeting.application.service;
+
+import com.code_factory.backend.budgeting.application.port.in.UpdateBudgetUseCase;
+import com.code_factory.backend.budgeting.application.port.out.BudgetRepositoryPort;
+import com.code_factory.backend.budgeting.domain.model.Budget;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateBudgetService implements UpdateBudgetUseCase {
+
+    private final BudgetRepositoryPort repository;
+
+    @Override
+    public void updateExpenseLimit(UUID userId, BigDecimal newLimit) {
+
+        LocalDate currentMonth = LocalDate.now().withDayOfMonth(1);
+
+        Budget budget = repository
+                .findByUserIdAndMonth(userId, currentMonth)
+                .orElseThrow(() -> new RuntimeException("Presupuesto no encontrado"));
+
+        Budget updated = budget.updateExpenseLimit(newLimit);
+
+        repository.save(updated);
+    }
+}

--- a/src/main/java/com/code_factory/backend/budgeting/domain/model/Budget.java
+++ b/src/main/java/com/code_factory/backend/budgeting/domain/model/Budget.java
@@ -2,6 +2,7 @@ package com.code_factory.backend.budgeting.domain.model;
 
 import lombok.Builder;
 import lombok.Getter;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -10,10 +11,31 @@ import java.util.UUID;
 @Getter
 @Builder
 public class Budget {
+
     private final UUID id;
     private final UUID userId;
     private final LocalDate month;
     private final BigDecimal totalIncome;
     private final BigDecimal expenseLimit;
     private final LocalDateTime createdAt;
+
+    /**
+     * Actualiza el límite de gasto (presupuesto mensual)
+     * Mantiene la inmutabilidad del objeto
+     */
+    public Budget updateExpenseLimit(BigDecimal newLimit) {
+
+        if (newLimit == null || newLimit.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("El valor debe ser mayor a 0");
+        }
+
+        return Budget.builder()
+                .id(this.id)
+                .userId(this.userId)
+                .month(this.month)
+                .totalIncome(this.totalIncome)
+                .expenseLimit(newLimit)
+                .createdAt(this.createdAt)
+                .build();
+    }
 }

--- a/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/in/web/BudgetController.java
+++ b/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/in/web/BudgetController.java
@@ -3,8 +3,11 @@ package com.code_factory.backend.budgeting.infrastructure.adapter.in.web;
 import com.code_factory.backend.budgeting.application.port.in.CreateBudgetCommand;
 import com.code_factory.backend.budgeting.application.port.in.CreateBudgetUseCase;
 import com.code_factory.backend.budgeting.application.port.in.ListBudgetsUseCase;
+import com.code_factory.backend.budgeting.application.port.in.UpdateBudgetUseCase;
 import com.code_factory.backend.budgeting.infrastructure.adapter.in.web.dto.BudgetResponse;
 import com.code_factory.backend.budgeting.infrastructure.adapter.in.web.dto.CreateBudgetRequest;
+import com.code_factory.backend.budgeting.infrastructure.adapter.in.web.dto.UpdateBudgetRequest;
+
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,16 +24,20 @@ public class BudgetController {
 
     private final CreateBudgetUseCase createBudgetUseCase;
     private final ListBudgetsUseCase listBudgetsUseCase;
+    private final UpdateBudgetUseCase updateBudgetUseCase; //  NUEVO
 
     @PostMapping
     public ResponseEntity<BudgetResponse> createBudget(@Valid @RequestBody CreateBudgetRequest request) {
+
         var command = new CreateBudgetCommand(
                 request.getUserId(),
                 request.getMonth(),
                 request.getTotalIncome(),
                 request.getExpenseLimit()
         );
+
         var budget = createBudgetUseCase.createBudget(command);
+
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(BudgetResponse.builder()
                         .id(budget.getId())
@@ -44,6 +51,7 @@ public class BudgetController {
 
     @GetMapping("/{userId}")
     public ResponseEntity<List<BudgetResponse>> getBudgetsByUser(@PathVariable UUID userId) {
+
         List<BudgetResponse> budgets = listBudgetsUseCase.getBudgetsByUserId(userId)
                 .stream()
                 .map(b -> BudgetResponse.builder()
@@ -55,6 +63,28 @@ public class BudgetController {
                         .createdAt(b.getCreatedAt())
                         .build())
                 .toList();
+
         return ResponseEntity.ok(budgets);
+    }
+
+    //  NUEVO MÉTODO (editar presupuesto)
+    @PutMapping("/monthly")
+    public ResponseEntity<?> updateBudget(@RequestBody @Valid UpdateBudgetRequest request) {
+
+        try {
+            updateBudgetUseCase.updateExpenseLimit(
+                    request.getUserId(),
+                    request.getNewLimit()
+            );
+
+            return ResponseEntity.ok("Presupuesto actualizado correctamente");
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("No se pudo completar la acción");
+        }
     }
 }

--- a/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/in/web/dto/UpdateBudgetRequest.java
+++ b/src/main/java/com/code_factory/backend/budgeting/infrastructure/adapter/in/web/dto/UpdateBudgetRequest.java
@@ -1,0 +1,19 @@
+package com.code_factory.backend.budgeting.infrastructure.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Getter
+public class UpdateBudgetRequest {
+
+    @NotNull
+    private UUID userId;
+
+    @NotNull
+    @Positive(message = "El valor debe ser mayor a 0")
+    private BigDecimal newLimit;
+}


### PR DESCRIPTION
Implementa la funcionalidad para editar un presupuesto mensual.

Permite modificar los datos de un presupuesto existente, como el monto asignado u otros campos relevantes, asegurando que los cambios se reflejen correctamente en el sistema.

**Cambios realizados**

- Implementación de la lógica para actualizar un presupuesto mensual

- Validaciones de los datos ingresados (ej: monto válido)

- Actualización de la información en la base de datos

- Manejo de errores en el proceso de edición