### PR TITLE
feat: implementar login con JWT y bloqueo por intentos fallidos

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - SPRING_DATASOURCE_USERNAME=pgli_admin
       - SPRING_DATASOURCE_PASSWORD=pgli_password
       - SPRING_JPA_HIBERNATE_DDL_AUTO=update
+      - JWT_SECRET=cGdsaV9zZWNyZXRfa2V5X3BhcmFfanNvbl93ZWJfdG9rZW5fMjAyNl9jb2RlX2ZhY3Rvcnk=
     depends_on:
       - db
     networks:

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,23 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.12.6</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.12.6</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.12.6</version>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/code_factory/backend/identity/application/port/in/LoginUserUseCase.java
+++ b/src/main/java/com/code_factory/backend/identity/application/port/in/LoginUserUseCase.java
@@ -1,0 +1,5 @@
+package com.code_factory.backend.identity.application.port.in;
+
+public interface LoginUserUseCase {
+    String login(String email, String password);
+}

--- a/src/main/java/com/code_factory/backend/identity/application/port/out/JwtTokenPort.java
+++ b/src/main/java/com/code_factory/backend/identity/application/port/out/JwtTokenPort.java
@@ -1,0 +1,9 @@
+package com.code_factory.backend.identity.application.port.out;
+
+import java.util.UUID;
+
+public interface JwtTokenPort {
+    String generateToken(UUID userId, String email);
+    String extractEmail(String token);
+    boolean isTokenValid(String token);
+}

--- a/src/main/java/com/code_factory/backend/identity/application/port/out/PasswordEncoderPort.java
+++ b/src/main/java/com/code_factory/backend/identity/application/port/out/PasswordEncoderPort.java
@@ -2,4 +2,5 @@ package com.code_factory.backend.identity.application.port.out;
 
 public interface PasswordEncoderPort {
     String encode(String rawPassword);
+    boolean matches(String rawPassword, String encodedPassword);
 }

--- a/src/main/java/com/code_factory/backend/identity/application/service/LoginUserService.java
+++ b/src/main/java/com/code_factory/backend/identity/application/service/LoginUserService.java
@@ -1,0 +1,51 @@
+package com.code_factory.backend.identity.application.service;
+
+import com.code_factory.backend.identity.application.port.in.LoginUserUseCase;
+import com.code_factory.backend.identity.application.port.out.JwtTokenPort;
+import com.code_factory.backend.identity.application.port.out.PasswordEncoderPort;
+import com.code_factory.backend.identity.application.port.out.UserRepositoryPort;
+import com.code_factory.backend.identity.domain.exception.AccountBlockedException;
+import com.code_factory.backend.identity.domain.exception.InvalidCredentialsException;
+import com.code_factory.backend.identity.domain.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class LoginUserService implements LoginUserUseCase {
+
+    private static final int MAX_FAILED_ATTEMPTS = 3;
+    private static final int BLOCK_DURATION_MINUTES = 15;
+
+    private final UserRepositoryPort userRepositoryPort;
+    private final PasswordEncoderPort passwordEncoderPort;
+    private final JwtTokenPort jwtTokenPort;
+
+    @Override
+    public String login(String email, String password) {
+        User user = userRepositoryPort.findByEmail(email)
+                .orElseThrow(InvalidCredentialsException::new);
+
+        if (user.getBlockedUntil() != null && user.getBlockedUntil().isAfter(LocalDateTime.now())) {
+            throw new AccountBlockedException(user.getBlockedUntil());
+        }
+
+        if (!passwordEncoderPort.matches(password, user.getPassword())) {
+            int attempts = user.getFailedAttempts() + 1;
+            user.setFailedAttempts(attempts);
+            if (attempts >= MAX_FAILED_ATTEMPTS) {
+                user.setBlockedUntil(LocalDateTime.now().plusMinutes(BLOCK_DURATION_MINUTES));
+            }
+            userRepositoryPort.save(user);
+            throw new InvalidCredentialsException();
+        }
+
+        user.setFailedAttempts(0);
+        user.setBlockedUntil(null);
+        userRepositoryPort.save(user);
+
+        return jwtTokenPort.generateToken(user.getId(), user.getEmail());
+    }
+}

--- a/src/main/java/com/code_factory/backend/identity/domain/exception/AccountBlockedException.java
+++ b/src/main/java/com/code_factory/backend/identity/domain/exception/AccountBlockedException.java
@@ -1,0 +1,10 @@
+package com.code_factory.backend.identity.domain.exception;
+
+import java.time.LocalDateTime;
+
+public class AccountBlockedException extends RuntimeException {
+
+    public AccountBlockedException(LocalDateTime blockedUntil) {
+        super("La cuenta está bloqueada temporalmente. Intente de nuevo después de las " + blockedUntil);
+    }
+}

--- a/src/main/java/com/code_factory/backend/identity/domain/exception/InvalidCredentialsException.java
+++ b/src/main/java/com/code_factory/backend/identity/domain/exception/InvalidCredentialsException.java
@@ -1,0 +1,8 @@
+package com.code_factory.backend.identity.domain.exception;
+
+public class InvalidCredentialsException extends RuntimeException {
+
+    public InvalidCredentialsException() {
+        super("Credenciales inválidas");
+    }
+}

--- a/src/main/java/com/code_factory/backend/identity/domain/model/User.java
+++ b/src/main/java/com/code_factory/backend/identity/domain/model/User.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 /**
@@ -19,10 +20,13 @@ import java.util.UUID;
 @AllArgsConstructor
 public class User {
 
-    private UUID id; 
+    private UUID id;
     private String firstName;
     private String lastName;
-    private String email; 
-    private String password;     
-    
+    private String email;
+    private String password;
+    @Builder.Default
+    private int failedAttempts = 0;
+    private LocalDateTime blockedUntil;
+
 }

--- a/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/in/web/UserController.java
+++ b/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/in/web/UserController.java
@@ -1,7 +1,10 @@
 package com.code_factory.backend.identity.infrastructure.adapter.in.web;
 
+import com.code_factory.backend.identity.application.port.in.LoginUserUseCase;
 import com.code_factory.backend.identity.application.port.in.RegisterUserUseCase;
 import com.code_factory.backend.identity.domain.model.User;
+import com.code_factory.backend.identity.infrastructure.adapter.in.web.dto.LoginRequest;
+import com.code_factory.backend.identity.infrastructure.adapter.in.web.dto.LoginResponse;
 import com.code_factory.backend.identity.infrastructure.adapter.in.web.dto.UserRegistrationRequest;
 import com.code_factory.backend.identity.application.port.in.FindUserUseCase;
 import com.code_factory.backend.identity.infrastructure.adapter.in.web.dto.UserResponse;
@@ -26,6 +29,13 @@ public class UserController {
 
     private final RegisterUserUseCase registerUserUseCase;
     private final FindUserUseCase findUserUseCase;
+    private final LoginUserUseCase loginUserUseCase;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        String token = loginUserUseCase.login(request.getEmail(), request.getPassword());
+        return ResponseEntity.ok(LoginResponse.builder().token(token).build());
+    }
 
     @PostMapping("/register")
     public ResponseEntity<?> register(@Valid @RequestBody UserRegistrationRequest request) {

--- a/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/in/web/dto/LoginRequest.java
+++ b/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/in/web/dto/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.code_factory.backend.identity.infrastructure.adapter.in.web.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/in/web/dto/LoginResponse.java
+++ b/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/in/web/dto/LoginResponse.java
@@ -1,0 +1,14 @@
+package com.code_factory.backend.identity.infrastructure.adapter.in.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponse {
+    private String token;
+}

--- a/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/in/web/dto/UserRegistrationRequest.java
+++ b/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/in/web/dto/UserRegistrationRequest.java
@@ -2,6 +2,7 @@ package com.code_factory.backend.identity.infrastructure.adapter.in.web.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
@@ -21,7 +22,11 @@ public class UserRegistrationRequest {
     private String email;
 
     @NotBlank(message = "La contraseña es obligatoria")
-    @Size(min = 8, message = "La contraseña debe tener al menos 8 caracteres") 
+    @Size(min = 8, message = "La contraseña debe tener al menos 8 caracteres")
+    @Pattern(
+        regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).+$",
+        message = "La contraseña debe contener al menos una mayúscula, una minúscula, un número y un carácter especial"
+    )
     private String password;
 
     @NotBlank(message = "Debes confirmar la contraseña")

--- a/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/persistence/entity/UserEntity.java
+++ b/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/persistence/entity/UserEntity.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -35,4 +36,11 @@ public class UserEntity {
 
     @Column(nullable = false)
     private String password;
+
+    @Column(nullable = false, columnDefinition = "int not null default 0")
+    @Builder.Default
+    private int failedAttempts = 0;
+
+    @Column(nullable = true)
+    private LocalDateTime blockedUntil;
 }

--- a/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/persistence/mapper/UserMapper.java
+++ b/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/persistence/mapper/UserMapper.java
@@ -16,6 +16,8 @@ public class UserMapper {
                 .lastName(domain.getLastName())
                 .email(domain.getEmail())
                 .password(domain.getPassword())
+                .failedAttempts(domain.getFailedAttempts())
+                .blockedUntil(domain.getBlockedUntil())
                 .build();
     }
 
@@ -28,6 +30,8 @@ public class UserMapper {
                 .lastName(entity.getLastName())
                 .email(entity.getEmail())
                 .password(entity.getPassword())
+                .failedAttempts(entity.getFailedAttempts())
+                .blockedUntil(entity.getBlockedUntil())
                 .build();
     }
 }

--- a/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/security/BCryptPasswordEncoderAdapter.java
+++ b/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/security/BCryptPasswordEncoderAdapter.java
@@ -15,4 +15,9 @@ public class BCryptPasswordEncoderAdapter implements PasswordEncoderPort {
     public String encode(String rawPassword) {
         return passwordEncoder.encode(rawPassword);
     }
+
+    @Override
+    public boolean matches(String rawPassword, String encodedPassword) {
+        return passwordEncoder.matches(rawPassword, encodedPassword);
+    }
 }

--- a/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/security/JwtTokenAdapter.java
+++ b/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/security/JwtTokenAdapter.java
@@ -1,0 +1,58 @@
+package com.code_factory.backend.identity.infrastructure.adapter.out.security;
+
+import com.code_factory.backend.identity.application.port.out.JwtTokenPort;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+public class JwtTokenAdapter implements JwtTokenPort {
+
+    private final SecretKey secretKey;
+    private final long expirationMs;
+
+    public JwtTokenAdapter(
+            @Value("${app.jwt.secret}") String secret,
+            @Value("${app.jwt.expiration-ms}") long expirationMs) {
+        this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+        this.expirationMs = expirationMs;
+    }
+
+    @Override
+    public String generateToken(UUID userId, String email) {
+        return Jwts.builder()
+                .subject(email)
+                .claim("userId", userId.toString())
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expirationMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    @Override
+    public String extractEmail(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+
+    @Override
+    public boolean isTokenValid(String token) {
+        try {
+            Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/security/UserDetailsServiceImpl.java
@@ -1,0 +1,30 @@
+package com.code_factory.backend.identity.infrastructure.adapter.out.security;
+
+import com.code_factory.backend.identity.application.port.out.UserRepositoryPort;
+import com.code_factory.backend.identity.domain.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepositoryPort userRepositoryPort;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepositoryPort.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado: " + email));
+
+        return new org.springframework.security.core.userdetails.User(
+                user.getEmail(),
+                user.getPassword(),
+                Collections.emptyList()
+        );
+    }
+}

--- a/src/main/java/com/code_factory/backend/shared/config/OpenApiConfig.java
+++ b/src/main/java/com/code_factory/backend/shared/config/OpenApiConfig.java
@@ -1,7 +1,10 @@
 package com.code_factory.backend.shared.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,6 +17,13 @@ public class OpenApiConfig {
                 .info(new Info()
                         .title("PGLI API - Personal Cash-Flow Guard")
                         .version("1.0")
-                        .description("Documentación de la API para la gestión de liquidez individual"));
+                        .description("Documentación de la API para la gestión de liquidez individual"))
+                .addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
+                .components(new Components()
+                        .addSecuritySchemes("Bearer Authentication", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("Ingresa el token JWT obtenido en /api/v1/auth/login")));
     }
 }

--- a/src/main/java/com/code_factory/backend/shared/config/SecurityConfig.java
+++ b/src/main/java/com/code_factory/backend/shared/config/SecurityConfig.java
@@ -1,12 +1,16 @@
 package com.code_factory.backend.shared.config;
 
+import com.code_factory.backend.shared.security.JwtAuthenticationFilter;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -18,12 +22,24 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   JwtAuthenticationFilter jwtAuthFilter) throws Exception {
         http
-            .csrf(csrf -> csrf.disable()) // Deshabilitamos CSRF para pruebas de API
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .anyRequest().permitAll() // Permitimos todo temporalmente
-            );
+                .requestMatchers("/api/v1/auth/login", "/api/v1/auth/register", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                .anyRequest().authenticated()
+            )
+            .exceptionHandling(ex -> ex
+                .authenticationEntryPoint((request, response, authException) -> {
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    response.setContentType("application/json");
+                    response.getWriter().write("{\"message\":\"No autorizado\",\"status\":401}");
+                })
+            )
+            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/src/main/java/com/code_factory/backend/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/code_factory/backend/shared/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.code_factory.backend.shared.exception;
 
+import com.code_factory.backend.identity.domain.exception.AccountBlockedException;
+import com.code_factory.backend.identity.domain.exception.InvalidCredentialsException;
 import com.code_factory.backend.shared.dto.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -33,6 +35,26 @@ public class GlobalExceptionHandler {
                 .build();
 
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidCredentials(InvalidCredentialsException ex) {
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .message(ex.getMessage())
+                .status(HttpStatus.UNAUTHORIZED.value())
+                .timestamp(LocalDateTime.now())
+                .build();
+        return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(AccountBlockedException.class)
+    public ResponseEntity<ErrorResponse> handleAccountBlocked(AccountBlockedException ex) {
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .message(ex.getMessage())
+                .status(HttpStatus.FORBIDDEN.value())
+                .timestamp(LocalDateTime.now())
+                .build();
+        return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
     }
 
     // Maneja excepciones de negocio (como el RuntimeException del Email) - Escenario 3

--- a/src/main/java/com/code_factory/backend/shared/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/code_factory/backend/shared/security/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package com.code_factory.backend.shared.security;
+
+import com.code_factory.backend.identity.application.port.out.JwtTokenPort;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenPort jwtTokenPort;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authHeader.substring(7);
+
+        if (!jwtTokenPort.isTokenValid(token)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String email = jwtTokenPort.extractEmail(token);
+
+        if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+            UsernamePasswordAuthenticationToken authToken =
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,3 +21,9 @@ spring.jpa.open-in-view=false
 # ===============================
 spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
+
+# ===============================
+# JWT CONFIGURATION
+# ===============================
+app.jwt.secret=${JWT_SECRET}
+app.jwt.expiration-ms=86400000


### PR DESCRIPTION
## Descripción

Implementación del flujo de autenticación completo cumpliendo las HU de inicio de sesión y la historia de abuso HA 1.2.1 (ataque de fuerza bruta).

## Cambios incluidos

- **Nuevo endpoint** `POST /api/v1/auth/login` — devuelve JWT en caso de éxito
- **Bloqueo temporal** de cuenta tras 3 intentos fallidos (15 minutos)
- **Mensaje de error genérico** para credenciales inválidas — no revela si falló el email o la contraseña
- **Política de contraseñas seguras** en el registro: mínimo 8 caracteres, mayúscula, minúscula, número y carácter especial
- **Filtro JWT** (`JwtAuthenticationFilter`) que protege todos los endpoints excepto `/login` y `/register`
- **Swagger** actualizado con soporte para Bearer token (botón Authorize)

## Historias de usuario cubiertas

- Rechazo por contraseña incorrecta → HTTP 401 con mensaje genérico
- Bloqueo por múltiples intentos fallidos → HTTP 403 tras el 3er intento
- Inicio de sesión con credenciales inválidas → HTTP 401 con mensaje genérico
- Inicio de sesión exitoso → HTTP 200 con `{ "token": "..." }`
- HA 1.2.1: limitación de intentos + política de contraseñas

## Evidencia

Video: https://ander20.neetorecord.com/watch/b46e503d176d32722b4c