### PR TITLE
feat: cierre de sesión con invalidación de token y expiración por inactividad

### DIFF
--- a/src/main/java/com/code_factory/backend/identity/application/port/in/LogoutUserUseCase.java
+++ b/src/main/java/com/code_factory/backend/identity/application/port/in/LogoutUserUseCase.java
@@ -1,0 +1,5 @@
+package com.code_factory.backend.identity.application.port.in;
+
+public interface LogoutUserUseCase {
+    void logout(String token);
+}

--- a/src/main/java/com/code_factory/backend/identity/application/port/out/JwtTokenPort.java
+++ b/src/main/java/com/code_factory/backend/identity/application/port/out/JwtTokenPort.java
@@ -3,7 +3,8 @@ package com.code_factory.backend.identity.application.port.out;
 import java.util.UUID;
 
 public interface JwtTokenPort {
-    String generateToken(UUID userId, String email);
+    String generateToken(UUID userId, String email, String jti);
     String extractEmail(String token);
+    String extractJti(String token);
     boolean isTokenValid(String token);
 }

--- a/src/main/java/com/code_factory/backend/identity/application/port/out/SessionRepositoryPort.java
+++ b/src/main/java/com/code_factory/backend/identity/application/port/out/SessionRepositoryPort.java
@@ -1,0 +1,12 @@
+package com.code_factory.backend.identity.application.port.out;
+
+import com.code_factory.backend.identity.application.port.out.dto.SessionInfo;
+
+import java.util.Optional;
+
+public interface SessionRepositoryPort {
+    void createSession(String jti, String userEmail);
+    Optional<SessionInfo> findByJti(String jti);
+    void revokeSession(String jti);
+    void updateLastActivity(String jti);
+}

--- a/src/main/java/com/code_factory/backend/identity/application/port/out/dto/SessionInfo.java
+++ b/src/main/java/com/code_factory/backend/identity/application/port/out/dto/SessionInfo.java
@@ -1,0 +1,5 @@
+package com.code_factory.backend.identity.application.port.out.dto;
+
+import java.time.LocalDateTime;
+
+public record SessionInfo(String jti, String userEmail, LocalDateTime lastActivityAt, boolean revoked) {}

--- a/src/main/java/com/code_factory/backend/identity/application/service/LoginUserService.java
+++ b/src/main/java/com/code_factory/backend/identity/application/service/LoginUserService.java
@@ -3,6 +3,7 @@ package com.code_factory.backend.identity.application.service;
 import com.code_factory.backend.identity.application.port.in.LoginUserUseCase;
 import com.code_factory.backend.identity.application.port.out.JwtTokenPort;
 import com.code_factory.backend.identity.application.port.out.PasswordEncoderPort;
+import com.code_factory.backend.identity.application.port.out.SessionRepositoryPort;
 import com.code_factory.backend.identity.application.port.out.UserRepositoryPort;
 import com.code_factory.backend.identity.domain.exception.AccountBlockedException;
 import com.code_factory.backend.identity.domain.exception.InvalidCredentialsException;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +24,7 @@ public class LoginUserService implements LoginUserUseCase {
     private final UserRepositoryPort userRepositoryPort;
     private final PasswordEncoderPort passwordEncoderPort;
     private final JwtTokenPort jwtTokenPort;
+    private final SessionRepositoryPort sessionRepositoryPort;
 
     @Override
     public String login(String email, String password) {
@@ -46,6 +49,8 @@ public class LoginUserService implements LoginUserUseCase {
         user.setBlockedUntil(null);
         userRepositoryPort.save(user);
 
-        return jwtTokenPort.generateToken(user.getId(), user.getEmail());
+        String jti = UUID.randomUUID().toString();
+        sessionRepositoryPort.createSession(jti, user.getEmail());
+        return jwtTokenPort.generateToken(user.getId(), user.getEmail(), jti);
     }
 }

--- a/src/main/java/com/code_factory/backend/identity/application/service/LogoutUserService.java
+++ b/src/main/java/com/code_factory/backend/identity/application/service/LogoutUserService.java
@@ -1,0 +1,21 @@
+package com.code_factory.backend.identity.application.service;
+
+import com.code_factory.backend.identity.application.port.in.LogoutUserUseCase;
+import com.code_factory.backend.identity.application.port.out.JwtTokenPort;
+import com.code_factory.backend.identity.application.port.out.SessionRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LogoutUserService implements LogoutUserUseCase {
+
+    private final JwtTokenPort jwtTokenPort;
+    private final SessionRepositoryPort sessionRepositoryPort;
+
+    @Override
+    public void logout(String token) {
+        String jti = jwtTokenPort.extractJti(token);
+        sessionRepositoryPort.revokeSession(jti);
+    }
+}

--- a/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/in/web/UserController.java
+++ b/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/in/web/UserController.java
@@ -1,6 +1,7 @@
 package com.code_factory.backend.identity.infrastructure.adapter.in.web;
 
 import com.code_factory.backend.identity.application.port.in.LoginUserUseCase;
+import com.code_factory.backend.identity.application.port.in.LogoutUserUseCase;
 import com.code_factory.backend.identity.application.port.in.RegisterUserUseCase;
 import com.code_factory.backend.identity.domain.model.User;
 import com.code_factory.backend.identity.infrastructure.adapter.in.web.dto.LoginRequest;
@@ -8,6 +9,7 @@ import com.code_factory.backend.identity.infrastructure.adapter.in.web.dto.Login
 import com.code_factory.backend.identity.infrastructure.adapter.in.web.dto.UserRegistrationRequest;
 import com.code_factory.backend.identity.application.port.in.FindUserUseCase;
 import com.code_factory.backend.identity.infrastructure.adapter.in.web.dto.UserResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -30,11 +32,21 @@ public class UserController {
     private final RegisterUserUseCase registerUserUseCase;
     private final FindUserUseCase findUserUseCase;
     private final LoginUserUseCase loginUserUseCase;
+    private final LogoutUserUseCase logoutUserUseCase;
 
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         String token = loginUserUseCase.login(request.getEmail(), request.getPassword());
         return ResponseEntity.ok(LoginResponse.builder().token(token).build());
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            logoutUserUseCase.logout(authHeader.substring(7));
+        }
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/register")

--- a/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/persistence/adapter/SessionPersistenceAdapter.java
+++ b/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/persistence/adapter/SessionPersistenceAdapter.java
@@ -1,0 +1,51 @@
+package com.code_factory.backend.identity.infrastructure.adapter.out.persistence.adapter;
+
+import com.code_factory.backend.identity.application.port.out.SessionRepositoryPort;
+import com.code_factory.backend.identity.application.port.out.dto.SessionInfo;
+import com.code_factory.backend.identity.infrastructure.adapter.out.persistence.entity.ActiveSessionEntity;
+import com.code_factory.backend.identity.infrastructure.adapter.out.persistence.repository.JpaActiveSessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class SessionPersistenceAdapter implements SessionRepositoryPort {
+
+    private final JpaActiveSessionRepository repository;
+
+    @Override
+    public void createSession(String jti, String userEmail) {
+        ActiveSessionEntity session = ActiveSessionEntity.builder()
+                .jti(jti)
+                .userEmail(userEmail)
+                .lastActivityAt(LocalDateTime.now())
+                .revoked(false)
+                .build();
+        repository.save(session);
+    }
+
+    @Override
+    public Optional<SessionInfo> findByJti(String jti) {
+        return repository.findByJti(jti)
+                .map(e -> new SessionInfo(e.getJti(), e.getUserEmail(), e.getLastActivityAt(), e.isRevoked()));
+    }
+
+    @Override
+    public void revokeSession(String jti) {
+        repository.findByJti(jti).ifPresent(session -> {
+            session.setRevoked(true);
+            repository.save(session);
+        });
+    }
+
+    @Override
+    public void updateLastActivity(String jti) {
+        repository.findByJti(jti).ifPresent(session -> {
+            session.setLastActivityAt(LocalDateTime.now());
+            repository.save(session);
+        });
+    }
+}

--- a/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/persistence/entity/ActiveSessionEntity.java
+++ b/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/persistence/entity/ActiveSessionEntity.java
@@ -1,0 +1,34 @@
+package com.code_factory.backend.identity.infrastructure.adapter.out.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "active_sessions")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ActiveSessionEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String jti;
+
+    @Column(nullable = false)
+    private String userEmail;
+
+    @Column(nullable = false)
+    private LocalDateTime lastActivityAt;
+
+    @Column(nullable = false, columnDefinition = "boolean not null default false")
+    @Builder.Default
+    private boolean revoked = false;
+}

--- a/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/persistence/repository/JpaActiveSessionRepository.java
+++ b/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/persistence/repository/JpaActiveSessionRepository.java
@@ -1,0 +1,11 @@
+package com.code_factory.backend.identity.infrastructure.adapter.out.persistence.repository;
+
+import com.code_factory.backend.identity.infrastructure.adapter.out.persistence.entity.ActiveSessionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface JpaActiveSessionRepository extends JpaRepository<ActiveSessionEntity, UUID> {
+    Optional<ActiveSessionEntity> findByJti(String jti);
+}

--- a/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/security/JwtTokenAdapter.java
+++ b/src/main/java/com/code_factory/backend/identity/infrastructure/adapter/out/security/JwtTokenAdapter.java
@@ -26,8 +26,9 @@ public class JwtTokenAdapter implements JwtTokenPort {
     }
 
     @Override
-    public String generateToken(UUID userId, String email) {
+    public String generateToken(UUID userId, String email, String jti) {
         return Jwts.builder()
+                .id(jti)
                 .subject(email)
                 .claim("userId", userId.toString())
                 .issuedAt(new Date())
@@ -44,6 +45,16 @@ public class JwtTokenAdapter implements JwtTokenPort {
                 .parseSignedClaims(token)
                 .getPayload()
                 .getSubject();
+    }
+
+    @Override
+    public String extractJti(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getId();
     }
 
     @Override

--- a/src/main/java/com/code_factory/backend/shared/config/SecurityConfig.java
+++ b/src/main/java/com/code_factory/backend/shared/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.code_factory.backend.shared.config;
 
 import com.code_factory.backend.shared.security.JwtAuthenticationFilter;
+import com.code_factory.backend.shared.security.SecurityHeadersFilter;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,7 +24,8 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http,
-                                                   JwtAuthenticationFilter jwtAuthFilter) throws Exception {
+                                                   JwtAuthenticationFilter jwtAuthFilter,
+                                                   SecurityHeadersFilter securityHeadersFilter) throws Exception {
         http
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session
@@ -39,7 +41,8 @@ public class SecurityConfig {
                     response.getWriter().write("{\"message\":\"No autorizado\",\"status\":401}");
                 })
             )
-            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(securityHeadersFilter, JwtAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/src/main/java/com/code_factory/backend/shared/config/SecurityConfig.java
+++ b/src/main/java/com/code_factory/backend/shared/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
             .exceptionHandling(ex -> ex
                 .authenticationEntryPoint((request, response, authException) -> {
                     response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                    response.setContentType("application/json");
+                    response.setContentType("application/json;charset=UTF-8");
                     response.getWriter().write("{\"message\":\"No autorizado\",\"status\":401}");
                 })
             )

--- a/src/main/java/com/code_factory/backend/shared/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/code_factory/backend/shared/security/JwtAuthenticationFilter.java
@@ -86,7 +86,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private void sendUnauthorized(HttpServletResponse response, String message) throws IOException {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.setContentType("application/json");
+        response.setContentType("application/json;charset=UTF-8");
         response.getWriter().write("{\"message\":\"" + message + "\",\"status\":401}");
     }
 }

--- a/src/main/java/com/code_factory/backend/shared/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/code_factory/backend/shared/security/JwtAuthenticationFilter.java
@@ -1,11 +1,14 @@
 package com.code_factory.backend.shared.security;
 
 import com.code_factory.backend.identity.application.port.out.JwtTokenPort;
+import com.code_factory.backend.identity.application.port.out.SessionRepositoryPort;
+import com.code_factory.backend.identity.application.port.out.dto.SessionInfo;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -15,13 +18,19 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Optional;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    private static final int INACTIVITY_TIMEOUT_MINUTES = 2;
+
     private final JwtTokenPort jwtTokenPort;
     private final UserDetailsService userDetailsService;
+    private final SessionRepositoryPort sessionRepositoryPort;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -42,8 +51,28 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        String email = jwtTokenPort.extractEmail(token);
+        String jti = jwtTokenPort.extractJti(token);
+        Optional<SessionInfo> sessionOpt = sessionRepositoryPort.findByJti(jti);
 
+        if (sessionOpt.isEmpty() || sessionOpt.get().revoked()) {
+            sessionOpt.ifPresent(s ->
+                log.warn("Intento de uso de token revocado. Email: {}, JTI: {}", s.userEmail(), jti)
+            );
+            sendUnauthorized(response, "Sesión no válida o expirada");
+            return;
+        }
+
+        SessionInfo session = sessionOpt.get();
+
+        if (session.lastActivityAt().isBefore(LocalDateTime.now().minusMinutes(INACTIVITY_TIMEOUT_MINUTES))) {
+            sessionRepositoryPort.revokeSession(jti);
+            sendUnauthorized(response, "Sesión expirada por inactividad");
+            return;
+        }
+
+        sessionRepositoryPort.updateLastActivity(jti);
+
+        String email = jwtTokenPort.extractEmail(token);
         if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
             UserDetails userDetails = userDetailsService.loadUserByUsername(email);
             UsernamePasswordAuthenticationToken authToken =
@@ -53,5 +82,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private void sendUnauthorized(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"message\":\"" + message + "\",\"status\":401}");
     }
 }

--- a/src/main/java/com/code_factory/backend/shared/security/SecurityHeadersFilter.java
+++ b/src/main/java/com/code_factory/backend/shared/security/SecurityHeadersFilter.java
@@ -1,0 +1,23 @@
+package com.code_factory.backend.shared.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class SecurityHeadersFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        response.setHeader("Cache-Control", "no-store, no-cache, must-revalidate");
+        response.setHeader("Pragma", "no-cache");
+        filterChain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
## Descripción

Implementación de la HU de cierre de sesión con mitigaciones de la HA 1.2.2 (Acceso no autorizado por sesión abierta).

## Cambios principales

- **Endpoint `POST /api/v1/auth/logout`**: revoca el token JWT en el servidor (tabla `active_sessions`)
- **Tabla `active_sessions`**: rastrea sesiones activas con el campo `jti` (JWT ID) embebido en cada token
- **Expiración por inactividad**: sesión se invalida automáticamente tras 2 minutos sin actividad (validación server-side en cada request)
- **Alerta en logs**: se registra un `WARN` cuando se detecta uso de token ya revocado, como indicio de posible robo de sesión
- **`Cache-Control: no-store`**: cabecera agregada a todas las respuestas para evitar que el botón "atrás" del navegador exponga contenido de sesiones cerradas

## Evidencia

Video:

https://ander20.neetorecord.com/watch/0ea43258f6d522e1d7ca